### PR TITLE
Remove unnecessary waitFor and navigationPromise

### DIFF
--- a/lib/activate.js
+++ b/lib/activate.js
@@ -42,29 +42,26 @@ async function start(email, password, alf, verification, emailPassword) {
     downloadPath: downloadPath
   });
 
-  const navigationPromise = page.waitForNavigation({
-    waitUntil: 'load'
-  });
-
   console.log('[INFO] Navigating to https://license.unity3d.com/manual');
 
-  await page.goto('https://license.unity3d.com/manual');
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'load' }),
+    page.goto('https://license.unity3d.com/manual')
+  ]);
 
   try {
-    await Promise.all([
-      await navigationPromise,
-      await page.waitForSelector('#new_conversations_create_session_form #conversations_create_session_form_password')
-    ]);
+    await page.waitForSelector('#new_conversations_create_session_form #conversations_create_session_form_password');
 
     console.log('[INFO] Start login...');
 
     await page.evaluate((text) => { (document.querySelector('input[type=email]')).value = text; }, email);
 
     await page.evaluate((text) => { (document.querySelector('input[type=password]')).value = text; }, password);
-    await page.click('input[name="commit"]');
 
-    await navigationPromise;
-    await page.waitFor(10000);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'load' }),
+      page.click('input[name="commit"]')
+    ]);
 
     const needVerify = await page.$('input[class="req"]');
 
@@ -74,13 +71,12 @@ async function start(email, password, alf, verification, emailPassword) {
 
       console.log('[INFO] Verification code: ' + confirmNumber);
 
-      await page.waitFor(1000);
-
       await page.evaluate((text) => { (document.querySelector('input[type=text]')).value = text; }, confirmNumber);
-      await page.click('input[name="commit"]');
 
-      await navigationPromise;
-      await page.waitFor(10000);
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'load' }),
+        page.click('input[name="commit"]'),
+      ]);
     } else {
       console.log('[INFO] No verification code is detected!');
     }
@@ -88,8 +84,6 @@ async function start(email, password, alf, verification, emailPassword) {
     console.log('[INFO] Drag license file...');
 
     const licenseFile = 'input[name="licenseFile"]';
-    await page.waitFor(10000);
-
     const input = await page.$(licenseFile);
 
     console.log('[INFO] Uploading alf file...');
@@ -97,9 +91,10 @@ async function start(email, password, alf, verification, emailPassword) {
     const alfPath = alf;
     await input.uploadFile(alfPath);
 
-    await page.click('input[name="commit"]');
-
-    await navigationPromise;
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'load' }),
+      page.click('input[name="commit"]')
+    ]);
 
     console.log('[INFO] Selecting license type...');
 
@@ -119,14 +114,12 @@ async function start(email, password, alf, verification, emailPassword) {
     );
 
     const nextButton = 'input[class="btn mb10"]';
-    await page.evaluate(
-      s => document.querySelector(s).click(),
-      nextButton
-    );
-
     await Promise.all([
-      await navigationPromise,
-      await page.waitFor(1000)
+      page.waitForNavigation({ waitUntil: "load" }),
+      page.evaluate(
+        s => document.querySelector(s).click(),
+        nextButton
+      )
     ]);
 
     await page.click('input[name="commit"]');


### PR DESCRIPTION
It seems that there are some Promise-related bugs and `page.waitFor` is called several times to work around them.

- `navigationPromise` is used several times, but it is a `Promise` instance (not a function to return a `Promise`), so once it is resolved, it is always resolved thereafter.
- [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) takes an iterable of promises as an input. When `Promise.all([await p1, await p2])` is called, `p1` is awaited then `p2` is awaited, and finally `Promise.all` is called.

This PR replaces `navigationPromise` with `page.waitForNavigation` and removes unnecessary `page.waitFor` calls.

I've tested the changes in my environment (I ran the `unity-license-activate` command from a [`unityci/editor`](https://hub.docker.com/layers/editor/unityci/editor/2021.3.5f1-base-1.0/images/sha256-4338ae6114aaffe2db554144947715a869e3ac5ef90638fe6149d0fb81fc184e?context=explore) container), but I've not confirmed the following block (`needVerify` conditional block), which is skipped for some reason.
https://github.com/game-ci/unity-license-activate/blob/395b5ad9fbee4aef905bdb1c5c5adec54962b9f2/lib/activate.js#L69-L79