### PR TITLE
Fix action failure in case "terms of service" popup appeared Fix #68

### DIFF
--- a/lib/activate.js
+++ b/lib/activate.js
@@ -63,6 +63,19 @@ async function start(email, password, alf, verification, emailPassword) {
       page.click('input[name="commit"]')
     ]);
 
+    console.log('[INFO] Check for "Terms of service" popup...');
+
+    const needTosAccept = await page.$('#new_conversations_accept_updated_tos_form');
+
+    if(needTosAccept) {
+      console.log('[INFO] "Terms of service" accept required, submit form...');
+
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'load' }),
+        page.$eval('form', form => form.submit())
+      ]);
+    }
+
     const needVerify = await page.$('input[class="req"]');
 
     if (needVerify) {


### PR DESCRIPTION
Fix action failing when Unity's "terms of service" popup appears
![error 2](https://user-images.githubusercontent.com/33436839/204497171-b65200e7-1ca7-46c0-a165-f94bb2b43485.png)
This PR fixes #68 
